### PR TITLE
Add font link to html file and update mobile spacing for landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,9 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Ranchers&display=swap" rel="stylesheet">  
     <link href="https://fonts.googleapis.com/css2?family=Creepster&display=swap" rel="stylesheet">
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=PT+Sans+Narrow&display=swap" rel="stylesheet">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/Components/LandingPage.css
+++ b/src/Components/LandingPage.css
@@ -97,7 +97,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	height: 100vh;
+	/* height: 100vh; */
 }
 
 .landing-page-container {
@@ -161,7 +161,7 @@
 .landing-page-buttons-container {
 	display: flex;
 	flex-direction: row;
-	justify-content: space-evenly;
+	justify-content: center;
 	align-items: center;
 	width: 75%;
 }

--- a/src/Components/MapPage.css
+++ b/src/Components/MapPage.css
@@ -119,6 +119,7 @@
 	.map-intro {
 		padding-top: 20px;
 		font-weight: bold;
+		color: white;
 	}
 
 	.search {


### PR DESCRIPTION
**Changes made to the codebase:**

- Add link for google font to html file to hopefully resolve the issue of the font not working on mobile. 
- Update spacing for landing page on mobile
- Update font color on map page to white for mobile

**How was it tested?**

- Chrome dev tools

**Type of Change**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor

**Issues**

- closes #

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new bugs

**Emoji of how you feel submitting this PR:**

- Emoji: 
